### PR TITLE
Add a tapped handler when message is tapped

### DIFF
--- a/SwiftMessageBar/SwiftMessageBar.swift
+++ b/SwiftMessageBar/SwiftMessageBar.swift
@@ -71,6 +71,8 @@ public final class SwiftMessageBar {
     
     private var messageWindow: MessageWindow?
     
+    public var tappedHandler : () -> () = {}
+    
     private func newMessageWindow() -> MessageWindow {
         let messageWindow = MessageWindow()
         messageWindow.frame = UIApplication.sharedApplication().keyWindow!.frame
@@ -172,6 +174,7 @@ public final class SwiftMessageBar {
     @objc func didTapMessage(gesture: UITapGestureRecognizer) {
         let message = gesture.view as! Message
         dismissMessage(message, fromGesture: true)
+        self.tappedHandler()
     }
     
     private func dismissMessage(message: Message, fromGesture: Bool) {

--- a/SwiftMessageBar/SwiftMessageBar.swift
+++ b/SwiftMessageBar/SwiftMessageBar.swift
@@ -71,7 +71,7 @@ public final class SwiftMessageBar {
     
     private var messageWindow: MessageWindow?
     
-    public var tappedHandler : () -> () = {}
+    public var tapHandler : (() -> Void)?
     
     private func newMessageWindow() -> MessageWindow {
         let messageWindow = MessageWindow()
@@ -174,7 +174,7 @@ public final class SwiftMessageBar {
     @objc func didTapMessage(gesture: UITapGestureRecognizer) {
         let message = gesture.view as! Message
         dismissMessage(message, fromGesture: true)
-        self.tappedHandler()
+        tapHandler?()
     }
     
     private func dismissMessage(message: Message, fromGesture: Bool) {


### PR DESCRIPTION
This is useful when you need to execute code in you app when the message is tapped.

```
SwiftMessageBar.showMessageWithTitle("Success", message: "The Message Body", type: .Success, duration: 5.0)

SwiftMessageBar.SharedMessageBar.tappedHandler = {
    print("I was tapped.")
}
```
