### PR TITLE
Allow SMB to build with Carthage under Xcode 7.3

### DIFF
--- a/SwiftMessageBar.xcodeproj/project.pbxproj
+++ b/SwiftMessageBar.xcodeproj/project.pbxproj
@@ -407,10 +407,7 @@
 		F2AB58FC1B28B33D001DCC74 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -425,10 +422,7 @@
 		F2AB58FD1B28B33D001DCC74 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = SwiftMessageBarTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";

--- a/SwiftMessageBar/SwiftMessageBar.swift
+++ b/SwiftMessageBar/SwiftMessageBar.swift
@@ -154,7 +154,7 @@ public final class SwiftMessageBar {
         message.hidden = false
         message.setNeedsUpdateConstraints()
         
-        let gesture = UITapGestureRecognizer(target: self, action: Selector("didTapMessage:"))
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(didTapMessage))
         message.addGestureRecognizer(gesture)
         
         UIView.animateWithDuration(SwiftMessageBar.ShowHideDuration,


### PR DESCRIPTION
This PR resolves two warning that prevent SMB from compiling using Carthage and Xcode 7.3.

It does two simple things, it alters the frameworks search path to remove a missing path, and it changes one dynamic selector to the new #selector syntax.

:)
