### PR TITLE
RootViewController issue when dismissed with Tap.

### DIFF
--- a/SwiftMessageBar/SwiftMessageBar.swift
+++ b/SwiftMessageBar/SwiftMessageBar.swift
@@ -263,8 +263,6 @@ public final class SwiftMessageBar {
           messageBar.dequeueNextMessage()
         } else {
             self?.resetTimer()
-            self?.isMessageVisible = false
-            self?.messageQueue.removeAll()
             self?.messageWindow = nil
         }
       }

--- a/SwiftMessageBar/SwiftMessageBar.swift
+++ b/SwiftMessageBar/SwiftMessageBar.swift
@@ -262,7 +262,10 @@ public final class SwiftMessageBar {
         if let messageBar = self , !messageBar.messageQueue.isEmpty {
           messageBar.dequeueNextMessage()
         } else {
-          self?.messageWindow = nil
+            self?.resetTimer()
+            self?.isMessageVisible = false
+            self?.messageQueue.removeAll()
+            self?.messageWindow = nil
         }
       }
     )


### PR DESCRIPTION
When the message bar is dismissed with tap, it will cause the `rootviewcontroller` hierarchy issue. I fixed the issue in my app. Please spare some thought why it was behaving like this and how it is fixed now.

I just got some time to look into it. While dismissing the message bar with tap, the timer is not getting invalidating so that was the main issue that was causing the issue. I believe we only need to call `resetTimer` when the `messageWindow` is set to nil like below,

```
if let messageBar = self , !messageBar.messageQueue.isEmpty {
          messageBar.dequeueNextMessage()
} else {
   self?.resetTimer()
   self?.messageWindow = nil
}
```

I'll verify in my main project and commit the updated solution.